### PR TITLE
Feat/staff api

### DIFF
--- a/app/assets/javascripts/api/v1/employees/clients.coffee
+++ b/app/assets/javascripts/api/v1/employees/clients.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/api/v1/employees/staffs.coffee
+++ b/app/assets/javascripts/api/v1/employees/staffs.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/api/v1/employees/clients.scss
+++ b/app/assets/stylesheets/api/v1/employees/clients.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the api::v1::employees::clients controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/api/v1/employees/staffs.scss
+++ b/app/assets/stylesheets/api/v1/employees/staffs.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the api::v1::employees::staffs controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/api/v1/employees/clients_controller.rb
+++ b/app/controllers/api/v1/employees/clients_controller.rb
@@ -1,0 +1,10 @@
+class Api::V1::Employees::ClientsController < Api::V1::ApplicationController
+  skip_before_action :verify_authenticity_token
+  before_action :check_token_and_key_to_api
+  before_action :set_client, only: [:update, :destroy]
+
+  private
+    def set_client
+      @client = Staff.find(params[:id])
+    end
+end

--- a/app/controllers/api/v1/employees/staffs_controller.rb
+++ b/app/controllers/api/v1/employees/staffs_controller.rb
@@ -1,0 +1,39 @@
+class Api::V1::Employees::StaffsController < Api::V1::ApplicationController
+  skip_before_action :verify_authenticity_token
+  before_action :check_token_and_key_to_api
+  before_action :set_staff, only: [:update, :destroy]
+
+  def create
+    staff = Staff.new(staff_params.merge(password: "password", password_confirmation: "password"))
+    if staff.save
+      render json: staff, serializer: StaffSerializer
+    else
+      render json: { status: "false", message: staff.errors.full_messages }
+    end
+  end
+
+  def update
+    if @staff.update(staff_params)
+      render json: @staff, serializer: StaffSerializer
+    else
+      render json: { status: "false", message: @staff.errors.full_messages }
+    end
+  end
+
+  def destroy
+    if @staff.destroy
+      render json: @staff, serializer: StaffSerializer
+    else
+      render json: { status: "false", message: @staff.errors.full_messages }
+    end
+  end
+
+  private
+    def staff_params
+      params.permit(:name, :login_id, :phone, :email, :birthed_on, :zipcode, :address, :department_id, :joined_on, :resigned_on)
+    end
+
+    def set_staff
+      @staff = Staff.find(params[:id])
+    end
+end

--- a/app/controllers/api/v1/employees/suppliers_controller.rb
+++ b/app/controllers/api/v1/employees/suppliers_controller.rb
@@ -1,0 +1,39 @@
+class Api::V1::Employees::SuppliersController < Api::V1::ApplicationController
+  skip_before_action :verify_authenticity_token
+  before_action :check_token_and_key_to_api
+  before_action :set_supplier, only: [:update, :destroy]
+
+  def create
+    supplier = Supplier.new(supplier_params)
+    if supplier.save
+      render json: supplier, serializer: SupplierSerializer
+    else
+      render json: { status: "false", message: supplier.errors.full_messages }
+    end
+  end
+
+  def update
+    if @supplier.update(supplier_params)
+      render json: @supplier, serializer: SupplierSerializer
+    else
+      render json: { status: "false", message: @supplier.errors.full_messages }
+    end
+  end
+
+  def destroy
+    if @supplier.destroy
+      render json: @supplier, serializer: SupplierSerializer
+    else
+      render json: { status: "false", message: @supplier.errors.full_messages }
+    end
+  end
+
+  private
+    def supplier_params
+      params.permit(:name, :address, :zip_code, :representative, :phone_1, :phone_2, :fax, :email)
+    end
+
+    def set_supplier
+      @supplier = Supplier.find(params[:id])
+    end
+end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::SessionsController < Api::V1::ApplicationController
-  protect_from_forgery
+  skip_before_action :verify_authenticity_token
   before_action :check_token_and_key_to_api
 
   def create

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,10 +60,7 @@ class ApplicationController < ActionController::Base
   # --------------------------------------------------------
         # TASK関係
   # --------------------------------------------------------
-  
-  def default_tasks
-    Task.where.not(default_title: nil).are_default_tasks
-  end
+
   
   # 並び順更新_____________________________________________________
   def reload_row_order(tasks)
@@ -72,20 +69,17 @@ class ApplicationController < ActionController::Base
     end
   end
       
-  def matter_task_type
-    if admin_signed_in? || manager_signed_in?
-      @default_tasks = Task.are_default_tasks
-    end
-    @matter_tasks = current_matter.tasks.are_matter_tasks
-    # row_orderリセット
-    reload_row_order(@matter_tasks)
-    @matter_progress_tasks = current_matter.tasks.are_progress_tasks
-    # row_orderリセット
-    reload_row_order(@matter_progress_tasks)
-    @matter_complete_tasks = current_matter.tasks.are_finished_tasks
-    # row_orderリセット
-    reload_row_order(@matter_complete_tasks)
-  end
+  # def matter_task_type
+  #   @matter_tasks = current_matter.tasks.are_matter
+  #   # row_orderリセット
+  #   reload_row_order(@matter_tasks)
+  #   @matter_progress_tasks = current_matter.tasks.are_progress
+  #   # row_orderリセット
+  #   reload_row_order(@matter_progress_tasks)
+  #   @matter_complete_tasks = current_matter.tasks.are_finished
+  #   # row_orderリセット
+  #   reload_row_order(@matter_complete_tasks)
+  # end
     
   private
   

--- a/app/controllers/employees/tasks_controller.rb
+++ b/app/controllers/employees/tasks_controller.rb
@@ -2,7 +2,6 @@ class Employees::TasksController < ApplicationController
   before_action :set_default_task, only: [:show, :edit, :update, :destroy, :default_task_update, :default_task_destroy]
   
   def index
-    default_tasks
     @default_tasks = default_tasks.are_default_tasks
     @default_task = Task.new
   end

--- a/app/helpers/api/v1/employees/clients_helper.rb
+++ b/app/helpers/api/v1/employees/clients_helper.rb
@@ -1,0 +1,2 @@
+module Api::V1::Employees::ClientsHelper
+end

--- a/app/helpers/api/v1/employees/staffs_helper.rb
+++ b/app/helpers/api/v1/employees/staffs_helper.rb
@@ -1,0 +1,2 @@
+module Api::V1::Employees::StaffsHelper
+end

--- a/app/helpers/api/v1/employees/suppliers_helper.rb
+++ b/app/helpers/api/v1/employees/suppliers_helper.rb
@@ -1,0 +1,2 @@
+module Api::V1::Employees::SuppliersHelper
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ApplicationRecord
   belongs_to :matter, inverse_of: :tasks, optional: true
-   after_initialize :set_default_task, if: :new_record?
+  after_initialize :set_default_task, if: :new_record?
   
   enum status: {default_tasks: 0, matter_tasks: 1, progress_tasks: 2, finished_tasks: 3}
    

--- a/app/serializers/supplier_serializer.rb
+++ b/app/serializers/supplier_serializer.rb
@@ -1,0 +1,4 @@
+class SupplierSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes 
+end

--- a/app/views/employees/tasks/default_task_create.js.erb
+++ b/app/views/employees/tasks/default_task_create.js.erb
@@ -1,0 +1,7 @@
+$(".task-create-errors").html('<%= escape_javascript(render partial: "shared/error_messages", locals: { resource: @default_task }) %>');
+<% @default_task.errors.messages.keys.each do |key_attribute| %>
+  var addDiv = $('<div class="field-with-errors">');
+  var addLabel = $('input[name="task[<%= key_attribute.intern.to_s %>]"]').prev();
+  $('input[name="task[<%= key_attribute.intern.to_s %>]"]').wrap(addDiv);
+  addLabel.wrap(addDiv);
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,16 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post "sign_in", to: "sessions#create"
+      
+      namespace :employees do
+        post "create_client", to: "clients#create"
+        post "update_client", to: "clients#update"
+        post "destroy_client", to: "clients#destroy"
+
+        post "create_supplier", to: "suppliers#create"
+        post "update_supplier", to: "suppliers#update"
+        post "destroy_supplier", to: "suppliers#destroy"
+      end
     end
   end
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,18 +5,27 @@ Rails.application.routes.draw do
   patch '/employees/tasks/:id', to: 'employees/tasks#default_task_update', as: 'default_task_employees_task_update'
   delete '/employees/tasks/:id', to: 'employees/tasks#default_task_destroy', as: 'default_task_employees_task_destroy'
 
+  # API関連
   namespace :api do
     namespace :v1 do
       post "sign_in", to: "sessions#create"
       
       namespace :employees do
+        # スタッフCRUD
+        post "create_staff", to: "staffs#create"
+        post "update_staff", to: "staffs#update"
+        post "destroy_staff", to: "staffs#destroy"
+
+        # 顧客CRUD
         post "create_client", to: "clients#create"
         post "update_client", to: "clients#update"
         post "destroy_client", to: "clients#destroy"
 
+        # 外注先CRUD
         post "create_supplier", to: "suppliers#create"
         post "update_supplier", to: "suppliers#update"
         post "destroy_supplier", to: "suppliers#destroy"
+
       end
     end
   end

--- a/db/migrate/20201103000000_create_staff_events.rb
+++ b/db/migrate/20201103000000_create_staff_events.rb
@@ -1,0 +1,10 @@
+class CreateStaffEvents < ActiveRecord::Migration[5.1]
+  def change
+    create_table :staff_events, id: :integer do |t|
+      t.integer :staff_id, foreign_key: true
+      t.integer :event_id, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201103000001_create_staff_event_titles.rb
+++ b/db/migrate/20201103000001_create_staff_event_titles.rb
@@ -1,0 +1,10 @@
+class CreateStaffEventTitles < ActiveRecord::Migration[5.1]
+  def change
+    create_table :staff_event_titles, id: :integer do |t|
+      t.integer :staff_id, foreign_key: true
+      t.integer :event_title_id, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201014074600) do
+ActiveRecord::Schema.define(version: 20201103000001) do
 
   create_table "admins", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", default: "", null: false
@@ -148,6 +148,20 @@ ActiveRecord::Schema.define(version: 20201014074600) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["client_id"], name: "index_matters_on_client_id"
+  end
+
+  create_table "staff_event_titles", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "staff_id"
+    t.integer "event_title_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "staff_events", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "staff_id"
+    t.integer "event_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "staffs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/helpers/api/v1/employees/clients_helper_spec.rb
+++ b/spec/helpers/api/v1/employees/clients_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::V1::Employees::ClientsHelper. For example:
+#
+# describe Api::V1::Employees::ClientsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::V1::Employees::ClientsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/api/v1/employees/staffs_helper_spec.rb
+++ b/spec/helpers/api/v1/employees/staffs_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::V1::Employees::StaffsHelper. For example:
+#
+# describe Api::V1::Employees::StaffsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::V1::Employees::StaffsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/api/v1/employees/suppliers_helper_spec.rb
+++ b/spec/helpers/api/v1/employees/suppliers_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::V1::SessionsHelper. For example:
+#
+# describe Api::V1::SessionsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::V1::SuppliersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/v1/employees/clients_request_spec.rb
+++ b/spec/requests/api/v1/employees/clients_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Employees::Clients", type: :request do
+
+end

--- a/spec/requests/api/v1/employees/staffs_request_spec.rb
+++ b/spec/requests/api/v1/employees/staffs_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Employees::Staffs", type: :request do
+
+end

--- a/spec/requests/api/v1/employees/suppliers_request_spec.rb
+++ b/spec/requests/api/v1/employees/suppliers_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Employees::Suppliers", type: :request do
+
+end


### PR DESCRIPTION
## やったこと

- apiでのStaffのCRUD操作を行えるようにしました。

## やらないこと

- 特になし

## できるようになること（ユーザ目線）

- StaffをCRUD操作するためのapi発行を致しました。
●作成→url/api/v1/employees/staff_create    staffs#create
●更新→url/api/v1/employees/staff_update    staffs#update
●削除→url/api/v1/employees/staff_destroy     staffs#destroy

## できなくなること（ユーザ目線）

- 特になし

## 動作確認

- 下記リンクのTrelloにPOSTMANでapi叩いた時のスクショを共有しております。
https://trello.com/c/gEGc649f/45-api%E3%81%A7%E3%81%AEstaff%E3%81%AEcrud%E6%93%8D%E4%BD%9C-feat-staffapi

## その他

- staffsテーブルの子テーブルであるstaff_eventsテーブルとstaff_event_titlesテーブルが存在しない為にdestroy実行時にエラーが起きてdestroyを行えなかった為、staff_eventsとstaff_event_titlesテーブルを作成しております。（テーブル作成時のマイグレーションファイルの作成方法につきまして、rails g modelコマンドでのマイグレーションファイル作成ではなく、手でファイル新規作成して、20201103000000_create_staff_events.rbと20201103000001_create_staff_event_titles.rbを作成しております。）
