### PR TITLE
attendanceレイアウト変更

### DIFF
--- a/app/views/employees/attendances/_base_table.html.erb
+++ b/app/views/employees/attendances/_base_table.html.erb
@@ -1,43 +1,48 @@
 <div class="text-left"><h5><%= employee_type %></h5></div>
 
-<table class="table table-sm common-table">
-  <tr>
-    <th>名前</th>
-    <% if employee_type == "外部Staff" %>
-      <th width=20%>外注先名</th>
-    <% end %>
-    <th width=20%>出勤</th>
-    <th width=20%>退勤</th>
-    <th width=20%>勤務</th>
-  </tr>
-  <% attendances.each do |attendance| %>
-    <% if attendance.finished_at.present? %>
-      <% finished_at = l(attendance.finished_at, format: :time) %>
-    <% else %>
-      <% finished_at = "not-entered" %>
-    <% end %>
-    <tr class="tr-link to-edit-attendance" data-toggle="modal" data-target="#attendance-edit" data-id="<%= attendance.id %>"
-        data-worled-on="<%= l(attendance.worked_on, format: :long) %>" data-started-at="<%= l(attendance.started_at, format: :time) %>" data-finished-at="<%= finished_at %>">
-      <td class="name">
-        <% if attendance.manager %>
-          <%= attendance.manager.name %>
-        <% elsif attendance.staff %>
-          <%= attendance.staff.name %>
-        <% elsif attendance.external_staff %>
-          <%= attendance.external_staff.name %>
-        <% end %>
-      </td>
+<% if employee_type == "Manager" && attendances.count == 0 %>
+  <h6>出勤無し</h6>
+<% else %>
+  <table class="table table-sm common-table">
+    <tr>
+      <th>名前</th>
       <% if employee_type == "外部Staff" %>
-        <td><%= attendance.external_staff.supplier.name %></td>
+        <th width=20%>外注先名</th>
       <% end %>
-      <td><%= l(attendance.started_at, format: :time) %></td>
-      <% if finished_nil?(attendance) %>
-        <td class="text-danger">
-            退勤未処理
-        </td>
-      <% end %>
-      <td><%= finished_at if attendance.finished_at.present? %></td>
-      <td><%= daily_working_time(attendance.working_minutes) if attendance.working_minutes.present? %></td>
+      <th width=20%>出勤</th>
+      <th width=20%>退勤</th>
+      <th width=20%>勤務</th>
     </tr>
-  <% end %>
-</table>
+    <% attendances.each do |attendance| %>
+      <% if attendance.finished_at.present? %>
+        <% finished_at = l(attendance.finished_at, format: :time) %>
+      <% else %>
+        <% finished_at = "not-entered" %>
+      <% end %>
+      <tr class="tr-link to-edit-attendance" data-toggle="modal" data-target="#attendance-edit" data-id="<%= attendance.id %>"
+         data-worled-on="<%= l(attendance.worked_on, format: :long) %>" data-started-at="<%= l(attendance.started_at, format: :time) %>" data-finished-at="<%= finished_at %>">
+        <td class="name">
+          <% if attendance.manager %>
+            <%= attendance.manager.name %>
+          <% elsif attendance.staff %>
+            <%= attendance.staff.name %>
+          <% elsif attendance.external_staff %>
+            <%= attendance.external_staff.name %>
+          <% end %>
+        </td>
+        <% if employee_type == "外部Staff" %>
+          <td width=20%><%= attendance.external_staff.supplier.name %></td>
+        <% end %>
+        <td width=20%><%= l(attendance.started_at, format: :time) %></td>
+        <% if finished_nil?(attendance) %>
+          <td class="text-danger" width=20%>
+              退勤未処理
+          </td>
+        <% else %>
+          <td width=20%><%= finished_at if attendance.finished_at.present? %></td>
+        <% end %>
+        <td width=20%><%= daily_working_time(attendance.working_minutes) if attendance.working_minutes.present? %></td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/app/views/employees/attendances/_base_table.html.erb
+++ b/app/views/employees/attendances/_base_table.html.erb
@@ -1,7 +1,7 @@
 <div class="text-left"><h5><%= employee_type %></h5></div>
 
 <% if employee_type == "Manager" && attendances.count == 0 %>
-  <h6>出勤無し</h6>
+  <h6>出勤なし</h6>
 <% else %>
   <table class="table table-sm common-table">
     <tr>

--- a/app/views/employees/attendances/daily.html.erb
+++ b/app/views/employees/attendances/daily.html.erb
@@ -20,9 +20,12 @@
     <div class="card-body">
       <div class="row">
         <div class="col-lg-12 col-md-12">
+        
           <%= render "employees/attendances/base_table", employee_type: "Manager", attendances: @manager_attendances %>
 
-          <%= render "employees/attendances/base_table", employee_type: "Staff", attendances: @staff_attendances %> 
+          <div class="my-5">
+            <%= render "employees/attendances/base_table", employee_type: "Staff", attendances: @staff_attendances %>
+          </div> 
 
           <%= render "employees/attendances/base_table", employee_type: "外部Staff", attendances: @external_staff_attendances %> 
         </div>


### PR DESCRIPTION
## やったこと

* このプルリクで何をしたのか？
下記の通り、「日別勤怠」画面で下記(1)~(3)の修正を行いました。
（１）下記画像の通り、tdの幅を揃えました。
  - PC表示の場合
![スクリーンショット 2020-12-25 8 07 52](https://user-images.githubusercontent.com/26350224/103113109-8f6c1600-469c-11eb-8681-b832fe1ced72.png)
  - スマホ表示(iphone 6/7/8表示)の場合
![スクリーンショット 2020-12-25 8 09 46](https://user-images.githubusercontent.com/26350224/103113338-a19a8400-469d-11eb-9cd9-244eca8414cd.png)
![スクリーンショット 2020-12-25 8 10 04](https://user-images.githubusercontent.com/26350224/103113350-af500980-469d-11eb-929a-903cc7b618c9.png)

（２）staffの表示の上下にマージン5pxを設定し、Manager, Staff, 外部Staffの勤怠が区別しやすい見やすいレイアウトにしました。
（３）下記画像の通りmanagerの部分はこの日の出退勤が存在しない場合、「出勤なし」と表示するようにしました。
  - PC表示の場合
![スクリーンショット 2020-12-25 8 08 16](https://user-images.githubusercontent.com/26350224/103113419-f6d69580-469d-11eb-8dd3-beaf7d7e2175.png)
  - スマホ表示(iphone 6/7/8表示)の場合
![スクリーンショット 2020-12-25 8 10 43](https://user-images.githubusercontent.com/26350224/103113450-1a99db80-469e-11eb-9e7a-9bb731c274c5.png)


## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）
* なし

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
* 「日別一覧」の画面が見やすい表示になります。

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
* なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？
* 「やったこと」の(1)〜(3)に記載した通り、レイアウトが修正されていることを目視で確認しました。

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
* なし
