### PR TITLE
matter詳細ページレイアウト変更

### DIFF
--- a/app/assets/stylesheets/employees/matters.scss
+++ b/app/assets/stylesheets/employees/matters.scss
@@ -1,3 +1,9 @@
 .kanban-container {
   margin: 0 auto;
 }
+
+.fixed-table-header {
+  th {
+    width: 130px;
+  }
+}

--- a/app/views/employees/matters/tab_pane/_detail.html.erb
+++ b/app/views/employees/matters/tab_pane/_detail.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-sm common-table">
+<table class="table table-sm common-table fixed-table-header">
   <tr>
     <th>タイトル</th>
     <td><%= @matter.title %></td>


### PR DESCRIPTION
## やったこと

* このプルリクで何をしたのか？
* matter詳細ページのthの部分が広かったので、下記画像の通りthの幅を130pxに固定して幅を調節しました。
![スクリーンショット 2020-12-27 13 36 51](https://user-images.githubusercontent.com/26350224/103164488-32fd2800-484f-11eb-80aa-70f6197b234c.png)


## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）
* なし

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）
* matter詳細ページが見やすいレイアウトになります。

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）
* なし

## 動作確認

* どのような動作確認を行ったのか？　結果はどうか？
*「やったこと」の画像の通りthの幅が調節されていることを目視確認しました。

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
* なし
